### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/interviews/admin.py
+++ b/interviews/admin.py
@@ -37,7 +37,7 @@ class InterviewAdmin(admin.ModelAdmin):
 
     def preview_link(self, obj):
         preview_url = reverse('interviews-preview', args=[obj.preview_hash, obj.slug])
-        return '<a href="%s">Preview</a>' % (preview_url,)
+        return '<a href="{0!s}">Preview</a>'.format(preview_url)
     preview_link.short_description = _(u'Preview')
     preview_link.allow_tags = True
 
@@ -73,7 +73,7 @@ class ProductAdmin(admin.ModelAdmin):
 
     def preview_link(self, obj):
         product_preview_url = reverse('product-detail', args=[obj.slug])
-        return '<a href="%s">Preview</a>' % (product_preview_url,)
+        return '<a href="{0!s}">Preview</a>'.format(product_preview_url)
     preview_link.short_description = _(u'Preview')
     preview_link.allow_tags = True
 

--- a/interviews/models.py
+++ b/interviews/models.py
@@ -77,7 +77,7 @@ class Interview(models.Model):
 
     @property
     def get_full_url(self):
-        return "http://%s%s" % (self.site.domain, self.get_absolute_url())
+        return "http://{0!s}{1!s}".format(self.site.domain, self.get_absolute_url())
 
     @property
     def answers(self):
@@ -89,7 +89,7 @@ class Interview(models.Model):
 
     @property
     def preview_hash(self):
-        return hashlib.md5("%s-%s-%s" % (self.id, self.slug, self.site_id)).hexdigest()
+        return hashlib.md5("{0!s}-{1!s}-{2!s}".format(self.id, self.slug, self.site_id)).hexdigest()
 
 
 class Picture(models.Model):
@@ -102,7 +102,7 @@ class Picture(models.Model):
         verbose_name_plural = _('Pictures')
 
     def __unicode__(self):
-        return "%s - %s (%s)" % (self.interview, self.image, self.legend)
+        return "{0!s} - {1!s} ({2!s})".format(self.interview, self.image, self.legend)
 
 
 class Answer(models.Model):
@@ -121,7 +121,7 @@ class Answer(models.Model):
         ordering = ['order']
 
     def __unicode__(self):
-        return u"%s Q. %s" % (self.interview, self.order)
+        return u"{0!s} Q. {1!s}".format(self.interview, self.order)
 
 
 class Quote(models.Model):
@@ -135,7 +135,7 @@ class Quote(models.Model):
         verbose_name_plural = _('Quotes')
 
     def __unicode__(self):
-        return u"%s : %s" % (self.author, self.quote)
+        return u"{0!s} : {1!s}".format(self.author, self.quote)
 
 
 class InterviewPicture(models.Model):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jibaku:interviews?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jibaku:interviews?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)